### PR TITLE
Add `@opentelemetry/api` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^18.1.0",
     "@openapi-typescript-infra/coconfig": "^4.2.2",
+    "@opentelemetry/api": "^1.6.0",
     "@opentelemetry/sdk-trace-base": "^1.17.0",
     "@opentelemetry/sdk-trace-node": "^1.17.0",
     "@semantic-release/commit-analyzer": "^11.1.0",
@@ -66,9 +67,11 @@
     "typescript": "^5.2.2",
     "vitest": "^0.34.6"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.6.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.6.0",
-    "@opentelemetry/instrumentation": "^0.43.0",
+    "@opentelemetry/instrumentation": "^0.46.0",
     "@opentelemetry/semantic-conventions": "^1.17.0"
   },
   "packageManager": "yarn@3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,18 +723,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation@npm:^0.43.0":
-  version: 0.43.0
-  resolution: "@opentelemetry/instrumentation@npm:0.43.0"
+"@opentelemetry/instrumentation@npm:^0.46.0":
+  version: 0.46.0
+  resolution: "@opentelemetry/instrumentation@npm:0.46.0"
   dependencies:
     "@types/shimmer": ^1.0.2
-    import-in-the-middle: 1.4.2
+    import-in-the-middle: 1.7.1
     require-in-the-middle: ^7.1.1
     semver: ^7.5.2
     shimmer: ^1.2.1
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 6ebb916fcce79884b931f0098fbe3e12835437226b7afab43ae64580e27b74747157e2ed2c1584952e42bd21c6e1c72ecbcf260143241b43f8e62803f6ece3a6
+  checksum: 9589058da858eeb99b52ba191f93d82b3076b83f4a6cb745666fa742ce7fab8a219fd96a2f2bfad9609984d7462aedbaafa266a1ec3abca57964fdda0e43f5d6
   languageName: node
   linkType: hard
 
@@ -3601,15 +3601,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-in-the-middle@npm:1.4.2":
-  version: 1.4.2
-  resolution: "import-in-the-middle@npm:1.4.2"
+"import-in-the-middle@npm:1.7.1":
+  version: 1.7.1
+  resolution: "import-in-the-middle@npm:1.7.1"
   dependencies:
     acorn: ^8.8.2
     acorn-import-assertions: ^1.9.0
     cjs-module-lexer: ^1.2.2
     module-details-from-path: ^1.0.3
-  checksum: 52971f821e9a3c94834cd5cf0ab5178321c07d4f4babd547b3cb24c4de21670d05b42ca1523890e7e90525c3bba6b7db7e54cf45421919b0b2712a34faa96ea5
+  checksum: 37cc8c75fb7eac60611bafafea7fc60f794d0931fdabcec516c8a26effe69e914b1f7e8116e98549c6fdd1fe88dcaebfdebf35d7f52c761b48b312e40f3bf323
   languageName: node
   linkType: hard
 
@@ -5224,7 +5224,7 @@ __metadata:
     "@commitlint/config-conventional": ^18.1.0
     "@openapi-typescript-infra/coconfig": ^4.2.2
     "@opentelemetry/api": ^1.6.0
-    "@opentelemetry/instrumentation": ^0.43.0
+    "@opentelemetry/instrumentation": ^0.46.0
     "@opentelemetry/sdk-trace-base": ^1.17.0
     "@opentelemetry/sdk-trace-node": ^1.17.0
     "@opentelemetry/semantic-conventions": ^1.17.0
@@ -5241,6 +5241,8 @@ __metadata:
     semantic-release: ^22.0.7
     typescript: ^5.2.2
     vitest: ^0.34.6
+  peerDependencies:
+    "@opentelemetry/api": ^1.6.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes #11 

PS: I couldn't run `yarn` to update the yarn lock because I'm using yarn v1. Recent versions of yarn give me all sort of problems.