### PR TITLE
fix: `fetch('').catch()` triggers unhandled rejection in debugger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,14 @@ function contentLengthFromResponseHeaders(headers: Buffer[]) {
   return undefined;
 }
 
+async function loadFetch() {
+  try {
+    await fetch('');
+  } catch (_) {
+    //
+  }
+}
+
 // A combination of https://github.com/elastic/apm-agent-nodejs and
 // https://github.com/gadget-inc/opentelemetry-instrumentations/blob/main/packages/opentelemetry-instrumentation-undici/src/index.ts
 export class FetchInstrumentation implements Instrumentation {
@@ -110,7 +118,7 @@ export class FetchInstrumentation implements Instrumentation {
 
   constructor(config: FetchInstrumentationConfig) {
     // Force load fetch API (since it's lazy loaded in Node 18)
-    fetch('').catch(() => {});
+    loadFetch();
     this.channelSubs = [];
     this.meter = metrics.getMeter(this.instrumentationName, this.instrumentationVersion);
     this.tracer = trace.getTracer(this.instrumentationName, this.instrumentationVersion);


### PR DESCRIPTION
Due to this v8 debugger issue:
https://issues.chromium.org/issues/41161875

`Promise.reject().catch(() => {})` results in the promise rejection still triggering `uncaught exception` in the debugger even though it's later caught.

This can cause tests to fail when they use the debugger:
https://github.com/getsentry/sentry-javascript/issues/12343

This PR changes the code to use a try/catch block in an async function which doesn't result in the above debugger issue.