### PR TITLE
Use minimal data URL for loading fetch()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,8 @@ function contentLengthFromResponseHeaders(headers: Buffer[]) {
 
 async function loadFetch() {
   try {
-    await fetch('');
+    const request = new Request('');
+    await fetch(request);
   } catch (_) {
     //
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,7 @@ function contentLengthFromResponseHeaders(headers: Buffer[]) {
 
 async function loadFetch() {
   try {
-    const request = new Request('');
-    await fetch(request);
+    await fetch('data:text');
   } catch (_) {
     //
   }


### PR DESCRIPTION
The issue (https://github.com/getsentry/sentry-javascript/issues/12343) that should have been resolved by this PR https://github.com/gas-buddy/opentelemetry-instrumentation-fetch-node/pull/15 did not work.

Providing a minimal data URL to Fetch() will not cause an unhandled promise exception and will result in a clean startup. The minimal data URL will also ensure that there is no network activity for the fetch() call, which will not make it depended on any connectivity requirements.

I started my project with Sentry (8.19) with the debugger enabled and it worked.

cc @timfish @djMax 